### PR TITLE
Remove redundant conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 function isFunction(fn) {
-  if (!fn) return false;
   return typeof fn === 'function';
 }
 


### PR DESCRIPTION
Hey man,

I was checking your profile out as JP asked me to help with NodeSchool and I saw your isFunction function. Maybe I am missing an edge-case but I feel like that first statement is redundant. typeof `undefined`, `null,` `[]`, and `false` === 'function' will all return false already. 
